### PR TITLE
Update GitHub Actions to requested versions

### DIFF
--- a/.github/workflows/isa-build.yml
+++ b/.github/workflows/isa-build.yml
@@ -28,7 +28,7 @@ jobs:
     steps:
     # Checkout the repository
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
       
@@ -58,7 +58,7 @@ jobs:
     # Upload the riscv-privileged PDF file
     - name: Upload riscv-privileged.pdf
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-privileged-${{ env.SHORT_SHA }}.pdf
         path: ${{ github.workspace }}/build/riscv-privileged.pdf
@@ -67,7 +67,7 @@ jobs:
     # Upload the riscv-privileged HTML file
     - name: Upload riscv-privileged.html
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-privileged-${{ env.SHORT_SHA }}.html
         path: ${{ github.workspace }}/build/riscv-privileged.html
@@ -76,7 +76,7 @@ jobs:
     # Upload the riscv-privileged EPUB file
     - name: Upload riscv-privileged.epub
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-privileged-${{ env.SHORT_SHA }}.epub
         path: ${{ github.workspace }}/build/riscv-privileged.epub
@@ -85,7 +85,7 @@ jobs:
     # Upload the riscv-unprivileged PDF file
     - name: Upload riscv-unprivileged.pdf
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-unprivileged-${{ env.SHORT_SHA }}.pdf
         path: ${{ github.workspace }}/build/riscv-unprivileged.pdf
@@ -94,7 +94,7 @@ jobs:
     # Upload the riscv-unprivileged HTML file
     - name: Upload riscv-unprivileged.html
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-unprivileged-${{ env.SHORT_SHA }}.html
         path: ${{ github.workspace }}/build/riscv-unprivileged.html
@@ -103,7 +103,7 @@ jobs:
     # Upload the riscv-unprivileged EPUB file
     - name: Upload riscv-unprivileged.epub
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-unprivileged-${{ env.SHORT_SHA }}.epub
         path: ${{ github.workspace }}/build/riscv-unprivileged.epub

--- a/.github/workflows/merge-and-release.yml
+++ b/.github/workflows/merge-and-release.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
       with:
         submodules: recursive
 
@@ -41,7 +41,7 @@ jobs:
     # Upload the riscv-privileged PDF file
     - name: Upload riscv-privileged.pdf
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-privileged-${{ env.SHORT_SHA }}.pdf
         path: ${{ github.workspace }}/build/riscv-privileged.pdf
@@ -49,7 +49,7 @@ jobs:
     # Upload the riscv-privileged HTML file
     - name: Upload riscv-privileged.html
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-privileged-${{ env.SHORT_SHA }}.html
         path: ${{ github.workspace }}/build/riscv-privileged.html
@@ -57,7 +57,7 @@ jobs:
     # Upload the riscv-privileged EPUB file
     - name: Upload riscv-privileged.epub
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-privileged-${{ env.SHORT_SHA }}.epub
         path: ${{ github.workspace }}/build/riscv-privileged.epub
@@ -65,7 +65,7 @@ jobs:
     # Upload the riscv-unprivileged PDF file
     - name: Upload riscv-unprivileged.pdf
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-unprivileged-${{ env.SHORT_SHA }}.pdf
         path: ${{ github.workspace }}/build/riscv-unprivileged.pdf
@@ -73,7 +73,7 @@ jobs:
     # Upload the riscv-unprivileged HTML file
     - name: Upload riscv-unprivileged.html
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-unprivileged-${{ env.SHORT_SHA }}.html
         path: ${{ github.workspace }}/build/riscv-unprivileged.html
@@ -81,7 +81,7 @@ jobs:
     # Upload the riscv-unprivileged EPUB file
     - name: Upload riscv-unprivileged.epub
       if: steps.build_files.outcome == 'success'
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v6
       with:
         name: riscv-unprivileged-${{ env.SHORT_SHA }}.epub
         path: ${{ github.workspace }}/build/riscv-unprivileged.epub


### PR DESCRIPTION
This updates GitHub Actions workflow references to the requested versions.

Targets:
- `actions/checkout` -> `v6`
- `actions/upload-artifact` -> `v6`
- `softprops/action-gh-release` -> `v2`
